### PR TITLE
Enforce coding standards + lint rules; fix violations

### DIFF
--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,27 @@
+# Coding Standards
+
+This project follows a clear, consistent naming convention to improve readability and maintainability.
+
+## Naming Conventions
+
+- Types and interfaces: PascalCase
+  - Examples: `User`, `OrderItem`, `ApiResponse`
+- Variables and functions: camelCase
+  - Examples: `userId`, `fetchUser`, `isLoading`
+- Constants: UPPER_CASE (for exported or global constants)
+  - Examples: `DEFAULT_TIMEOUT_MS`, `API_BASE_URL`
+
+Notes:
+
+- React components (functions or consts that return JSX) should use PascalCase as they are components, not regular functions.
+- Files and directories should generally use kebab-case unless framework conventions dictate otherwise.
+
+## ESLint Enforcement
+
+The ESLint configuration enforces the above via `@typescript-eslint/naming-convention`. Additional rules include:
+
+- `@typescript-eslint/consistent-type-definitions`: enforce `interface` for object types
+- `prefer-const`: require `const` when variables are never reassigned
+- `no-var`: disallow `var`
+
+These rules are configured in `eslint.config.mjs`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,76 @@ const eslintConfig = [
           'newlines-between': 'always',
         },
       ],
+      // Prefer modern variable declarations
+      'prefer-const': 'error',
+      'no-var': 'error',
+
+      // Enforce consistent type definition style
+      '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+
+      // Naming conventions
+      '@typescript-eslint/naming-convention': [
+        'error',
+        // Types, Interfaces, Classes, Enums -> PascalCase
+        {
+          selector: 'typeLike',
+          format: ['PascalCase'],
+        },
+        // Functions -> camelCase or PascalCase (for React components)
+        {
+          selector: 'function',
+          format: ['camelCase', 'PascalCase'],
+          leadingUnderscore: 'allow',
+        },
+        // Variables (default) -> camelCase
+        {
+          selector: 'variable',
+          format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+          leadingUnderscore: 'allowDouble',
+        },
+        // Parameters -> camelCase (allow leading underscore when intentionally unused)
+        {
+          selector: 'parameter',
+          format: ['camelCase'],
+          leadingUnderscore: 'allow',
+        },
+      ],
+    },
+  },
+  // Stricter constant naming in dedicated constants files/directories
+  {
+    files: ['src/shared/constants/**', 'src/**/constants.ts', 'src/**/constants/*.ts'],
+    rules: {
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: 'typeLike',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'function',
+          format: ['camelCase', 'PascalCase'],
+          leadingUnderscore: 'allow',
+        },
+        // In constants files, exported consts must be UPPER_CASE
+        {
+          selector: 'variable',
+          modifiers: ['const', 'exported'],
+          format: ['UPPER_CASE'],
+          leadingUnderscore: 'allow',
+        },
+        // Default variables can still be camelCase for internal helpers
+        {
+          selector: 'variable',
+          format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+          leadingUnderscore: 'allowDouble',
+        },
+        {
+          selector: 'parameter',
+          format: ['camelCase'],
+          leadingUnderscore: 'allow',
+        },
+      ],
     },
   },
   {

--- a/src/components/dashboard/AccountMenu.tsx
+++ b/src/components/dashboard/AccountMenu.tsx
@@ -18,13 +18,13 @@ import {
 import { auth } from '@/infrastructure/supabase/utils';
 import { getInitials } from '@/shared/utils/user';
 
-type Props = {
+interface Props {
   user: {
     name?: string;
     email?: string;
     avatarUrl?: string;
   };
-};
+}
 
 export function AccountMenu({ user }: Props) {
   const router = useRouter();

--- a/src/components/dashboard/SidebarNav.tsx
+++ b/src/components/dashboard/SidebarNav.tsx
@@ -13,12 +13,12 @@ import {
 } from '@/components/ui/navigation-menu';
 import { withLocaleHref } from '@/i18n/routing';
 
-type NavItem = {
+interface NavItem {
   href?: string;
   key: 'overview' | 'qrCodes' | 'analytics' | 'settings';
   icon: React.ComponentType<{ className?: string }>;
   soon?: boolean;
-};
+}
 
 const items: NavItem[] = [
   { href: '/dashboard', key: 'overview', icon: LayoutDashboard },
@@ -46,33 +46,36 @@ export function SidebarNav() {
       className="w-full max-w-full justify-start [&>div]:w-full [&>div]:flex-1"
     >
       <NavigationMenuList className="flex w-full flex-col gap-1 p-2">
-        {items.map(({ href, key, icon: Icon, soon }) => (
-          <NavigationMenuItem key={key} className="w-full">
-            {href && !soon ? (
-              <NavigationMenuLink asChild data-active={isActive(href)}>
-                <Link
-                  href={withLocaleHref(href, locale)}
-                  aria-current={isActive(href) ? 'page' : undefined}
-                  className="flex w-full flex-row items-center gap-2 rounded-sm py-2 pl-[calc(theme(spacing.4)-theme(spacing.2))] sm:pl-[calc(theme(spacing.6)-theme(spacing.2))] lg:pl-[calc(theme(spacing.8)-theme(spacing.2))] transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+        {items.map((item) => {
+          const { href, key, icon: Icon, soon } = item;
+          return (
+            <NavigationMenuItem key={key} className="w-full">
+              {href && !soon ? (
+                <NavigationMenuLink asChild data-active={isActive(href)}>
+                  <Link
+                    href={withLocaleHref(href, locale)}
+                    aria-current={isActive(href) ? 'page' : undefined}
+                    className="flex w-full flex-row items-center gap-2 rounded-sm py-2 pl-[calc(theme(spacing.4)-theme(spacing.2))] sm:pl-[calc(theme(spacing.6)-theme(spacing.2))] lg:pl-[calc(theme(spacing.8)-theme(spacing.2))] transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+                  >
+                    {Icon && <Icon className="size-4" aria-hidden="true" />}
+                    <span>{t(key)}</span>
+                  </Link>
+                </NavigationMenuLink>
+              ) : (
+                <div
+                  className="flex w-full items-center gap-2 rounded-sm py-2 pl-[calc(theme(spacing.4)-theme(spacing.2))] sm:pl-[calc(theme(spacing.6)-theme(spacing.2))] lg:pl-[calc(theme(spacing.8)-theme(spacing.2))] text-muted-foreground"
+                  aria-disabled="true"
                 >
-                  <Icon className="size-4" aria-hidden="true" />
+                  {Icon && <Icon className="size-4" aria-hidden="true" />}
                   <span>{t(key)}</span>
-                </Link>
-              </NavigationMenuLink>
-            ) : (
-              <div
-                className="flex w-full items-center gap-2 rounded-sm py-2 pl-[calc(theme(spacing.4)-theme(spacing.2))] sm:pl-[calc(theme(spacing.6)-theme(spacing.2))] lg:pl-[calc(theme(spacing.8)-theme(spacing.2))] text-muted-foreground"
-                aria-disabled="true"
-              >
-                <Icon className="size-4" aria-hidden="true" />
-                <span>{t(key)}</span>
-                <span className="ml-auto inline-block rounded bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-secondary-foreground">
-                  {t('soon')}
-                </span>
-              </div>
-            )}
-          </NavigationMenuItem>
-        ))}
+                  <span className="ml-auto inline-block rounded bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-secondary-foreground">
+                    {t('soon')}
+                  </span>
+                </div>
+              )}
+            </NavigationMenuItem>
+          );
+        })}
       </NavigationMenuList>
     </NavigationMenu>
   );

--- a/src/components/layout/ComingSoon.tsx
+++ b/src/components/layout/ComingSoon.tsx
@@ -6,20 +6,21 @@ import { Heading } from '@/components/typography/Heading';
 import { Text } from '@/components/typography/Text';
 import { Button } from '@/components/ui/button';
 
-type Cta = {
+interface Cta {
   href: string;
   label: string;
-};
+}
 
-type Props = {
+interface Props {
   title: string;
   description?: string;
   icon?: React.ComponentType<{ className?: string }>;
   cta?: Cta;
   className?: string;
-};
+}
 
-export function ComingSoon({ title, description, icon: Icon = Clock, cta, className }: Props) {
+export function ComingSoon({ title, description, icon: iconProp = Clock, cta, className }: Props) {
+  const Icon = iconProp;
   return (
     <section className={className} aria-labelledby="coming-soon-title">
       <div className="py-10 md:py-16 px-page max-w-2xl mx-auto text-center">

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -18,12 +18,12 @@ import { Label } from '@/components/ui/label';
 
 const Form = FormProvider;
 
-type FormFieldContextValue<
+interface FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> = {
+> {
   name: TName;
-};
+}
 
 const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
 
@@ -63,9 +63,9 @@ const useFormField = () => {
   };
 };
 
-type FormItemContextValue = {
+interface FormItemContextValue {
   id: string;
-};
+}
 
 const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
 

--- a/src/features/auth/UserOrgProvider.tsx
+++ b/src/features/auth/UserOrgProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useMemo } from 'react';
 
-type UserOrgContextValue = {
+interface UserOrgContextValue {
   userId: string;
   email: string;
   name?: string | null;
@@ -10,7 +10,7 @@ type UserOrgContextValue = {
   orgId: string;
   orgName: string;
   orgRole: string; // keep as string to avoid importing enums here
-};
+}
 
 const UserOrgContext = createContext<UserOrgContextValue | null>(null);
 

--- a/src/i18n/zod.ts
+++ b/src/i18n/zod.ts
@@ -1,12 +1,12 @@
 export type TFn = (key: string, values?: Record<string, unknown>) => string;
-type IssueLike = {
+interface IssueLike {
   code: string;
   path?: Array<string | number>;
   type?: string;
   minimum?: number;
   maximum?: number;
   validation?: string;
-};
+}
 export type ZodErrorMapLike = (
   issue: IssueLike,
   ctx: { defaultError?: string },

--- a/src/infrastructure/supabase/crud.ts
+++ b/src/infrastructure/supabase/crud.ts
@@ -6,20 +6,20 @@ import type { Database, TableName } from '@shared/types';
 type Filter = Record<string, string | number | boolean>;
 
 // Minimal builder shapes to avoid strict generic coupling with Supabase's internal types
-type InsertBuilder<TValues> = {
+interface InsertBuilder<TValues> {
   insert: (values: TValues) => {
     select: () => Promise<{ data: unknown; error: PostgrestError | null }>;
   };
-};
+}
 
-type UpdateFilterBuilder = {
+interface UpdateFilterBuilder {
   eq: (column: string, value: string | number | boolean) => UpdateFilterBuilder;
   select: () => Promise<{ data: unknown; error: PostgrestError | null }>;
-};
+}
 
-type UpdateBuilder<TValues> = {
+interface UpdateBuilder<TValues> {
   update: (values: TValues) => UpdateFilterBuilder;
-};
+}
 
 // (DeleteFilterBuilder removed to avoid unused type)
 

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -1,6 +1,6 @@
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
-export type Database = {
+export interface Database {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
@@ -312,7 +312,7 @@ export type Database = {
       [_ in never]: never;
     };
   };
-};
+}
 
 type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
 

--- a/tests/integration/api/trpc/qr-router.test.ts
+++ b/tests/integration/api/trpc/qr-router.test.ts
@@ -4,7 +4,7 @@ import type { AppRouter } from '@infra/trpc/root';
 
 type Ctx = Parameters<AppRouter['createCaller']>[0];
 
-type QrRowSubset = {
+interface QrRowSubset {
   id: string;
   org_id: string;
   name: string;
@@ -13,7 +13,7 @@ type QrRowSubset = {
   svg_path: string | null;
   png_path: string | null;
   status: string;
-};
+}
 
 function createCtx(opts?: {
   user?: { id: string; email: string } | null;


### PR DESCRIPTION
This PR formalizes naming conventions and enforces them via ESLint, plus fixes code to comply.

Docs
- Add docs/coding-standards.md covering:
  - PascalCase: types/interfaces/classes/enums
  - camelCase: variables/functions/params
  - UPPER_CASE: exported constants (scoped to constants files)
  - Note React components are PascalCase; files generally kebab-case

ESLint
- Add @typescript-eslint/naming-convention
  - PascalCase for type-like
  - camelCase or PascalCase for functions (allows React components)
  - default variables camelCase; allow UPPER_CASE/PascalCase where needed
  - Scope UPPER_CASE for exported consts to constants files: src/shared/constants/**, src/**/constants.ts, src/**/constants/*.ts
- Add prefer-const, no-var
- Enforce @typescript-eslint/consistent-type-definitions = interface

Code changes
- Replace object type aliases with interfaces in flagged files
- Rename Icon-like params to camelCase and alias in JSX

Verification
- Ran npm run lint: clean
- Typecheck and build pass (pre-push hook)

Let me know if you prefer enforcing 'type' for object shapes; I can flip the rule and adjust docs accordingly.