### PR TITLE
test: shared helpers + auth guards refactor, QR update-error test

### DIFF
--- a/tests/unit/features/auth/auth-server-guards-extended.unit.test.ts
+++ b/tests/unit/features/auth/auth-server-guards-extended.unit.test.ts
@@ -1,0 +1,164 @@
+/* eslint-disable import/order */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthError } from '@supabase/supabase-js';
+
+import {
+  createMockSupabaseClient,
+  buildOrgMemberMaybeSingle,
+  expectRedirect,
+  asMock,
+} from '@test/utils';
+
+// Redirect mock
+vi.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  },
+}));
+
+// Locale mock used during redirects
+vi.mock('next-intl/server', () => ({
+  getLocale: async () => 'en',
+}));
+
+// Supabase client mocks (read-write and read-only)
+const mockRW = createMockSupabaseClient();
+const mockRO = createMockSupabaseClient();
+
+vi.mock('@infra/supabase/clients/server-client', () => ({
+  getSupabaseServerClient: async () => mockRW,
+  getSupabaseServerClientReadOnly: async () => mockRO ?? mockRW,
+}));
+
+// Import after mocks
+import * as authServer from '@/features/auth/server';
+
+describe('Auth Server - extended guards and helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getSession', () => {
+    it('returns session when present', async () => {
+      const session = { access_token: 't' };
+      asMock(mockRW.auth.getSession).mockResolvedValue({ data: { session }, error: null });
+      await expect(authServer.getSession()).resolves.toBe(session);
+    });
+
+    it('returns null when no session', async () => {
+      asMock(mockRW.auth.getSession).mockResolvedValue({ data: { session: null }, error: null });
+      await expect(authServer.getSession()).resolves.toBeNull();
+    });
+  });
+
+  describe('getCurrentUser', () => {
+    it('returns null when no authenticated user', async () => {
+      asMock(mockRW.auth.getUser).mockResolvedValue({ data: { user: null }, error: null });
+      await expect(authServer.getCurrentUser()).resolves.toBeNull();
+    });
+
+    it('returns null and reports when org lookup fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      asMock(mockRW.auth.getUser).mockResolvedValue({ data: { user: { id: 'uid' } }, error: null });
+      asMock(mockRW.from).mockReturnValue(buildOrgMemberMaybeSingle(null, { message: 'db error' }));
+      await expect(authServer.getCurrentUser()).resolves.toBeNull();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Server component variants (read-only client)', () => {
+    it('getUserIdForServerComponent returns id when available', async () => {
+      asMock(mockRO.auth.getUser).mockResolvedValue({ data: { user: { id: 'u1' } }, error: null });
+      await expect(authServer.getUserIdForServerComponent()).resolves.toBe('u1');
+    });
+
+    it('getUserIdForServerComponent returns null on AuthError refresh token issue', async () => {
+      asMock(mockRO.auth.getUser).mockRejectedValue(new AuthError('refresh_token_not_found'));
+      await expect(authServer.getUserIdForServerComponent()).resolves.toBeNull();
+    });
+
+    it('getUserIdForServerComponent rethrows unknown errors', async () => {
+      asMock(mockRO.auth.getUser).mockRejectedValue(new Error('boom'));
+      await expect(authServer.getUserIdForServerComponent()).rejects.toThrow('boom');
+    });
+
+    it('getCurrentUserForServerComponent returns null for unauthenticated', async () => {
+      asMock(mockRO.auth.getUser).mockResolvedValue({ data: { user: null }, error: null });
+      await expect(authServer.getCurrentUserForServerComponent()).resolves.toBeNull();
+    });
+
+    it('getCurrentUserForServerComponent returns a full user with org on success', async () => {
+      asMock(mockRO.auth.getUser).mockResolvedValue({ data: { user: { id: 'u2' } }, error: null });
+      asMock(mockRO.from).mockReturnValue(
+        buildOrgMemberMaybeSingle({
+          role: 'admin',
+          org: { id: 'org-9', name: 'Acme' },
+          user: { id: 'u2', email: 'u2@example.com', name: 'User Two', avatar_url: 'a.png' },
+        }),
+      );
+      const u = await authServer.getCurrentUserForServerComponent();
+      expect(u?.id).toBe('u2');
+      expect(u?.org_id).toBe('org-9');
+      expect(u?.org_role).toBe('admin');
+    });
+
+    it('getCurrentUserForServerComponent swallows AuthError and returns null', async () => {
+      asMock(mockRO.auth.getUser).mockRejectedValue(new AuthError('refresh_token_not_found'));
+      await expect(authServer.getCurrentUserForServerComponent()).resolves.toBeNull();
+    });
+
+    it('getCurrentUserForServerComponent returns null and reports when org lookup fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      asMock(mockRO.auth.getUser).mockResolvedValue({ data: { user: { id: 'u2' } }, error: null });
+      asMock(mockRO.from).mockReturnValue(buildOrgMemberMaybeSingle(null, { message: 'db fail' }));
+      await expect(authServer.getCurrentUserForServerComponent()).resolves.toBeNull();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('requireUserIdForServerComponent redirects when unauthenticated', async () => {
+      asMock(mockRO.auth.getUser).mockResolvedValue({ data: { user: null }, error: null });
+      await expectRedirect(() => authServer.requireUserIdForServerComponent(), '/en/sign-in');
+    });
+
+    it('requireCurrentUserForServerComponent redirects when unauthenticated', async () => {
+      asMock(mockRO.auth.getUser).mockResolvedValue({ data: { user: null }, error: null });
+      await expectRedirect(() => authServer.requireCurrentUserForServerComponent(), '/en/sign-in');
+    });
+
+    it('redirectIfAuthenticatedForServerComponent redirects to dashboard when authenticated', async () => {
+      asMock(mockRO.auth.getUser).mockResolvedValue({ data: { user: { id: 'u3' } }, error: null });
+      asMock(mockRO.from).mockReturnValue(
+        buildOrgMemberMaybeSingle({
+          role: 'viewer',
+          org: { id: 'org-2', name: 'Org' },
+          user: { id: 'u3', email: 'u3@example.com', name: 'U3', avatar_url: null },
+        }),
+      );
+      await expectRedirect(
+        () => authServer.redirectIfAuthenticatedForServerComponent(),
+        '/en/dashboard',
+      );
+    });
+  });
+
+  describe('ensureUserAndOrg - failure paths', () => {
+    it('reports and throws when RPC returns error', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      asMock(mockRW.rpc).mockResolvedValue({ data: null, error: { message: 'rpc failed' } });
+      await expect(authServer.ensureUserAndOrg('u', 'e@example.com', 'N')).rejects.toThrow(
+        /Failed to ensure user and org/i,
+      );
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('throws when RPC returns null org id without error', async () => {
+      asMock(mockRW.rpc).mockResolvedValue({ data: null, error: null });
+      await expect(authServer.ensureUserAndOrg('u', 'e@example.com')).rejects.toThrow(
+        /null org ID/i,
+      );
+    });
+  });
+});

--- a/tests/unit/lib/utils-cn.unit.test.ts
+++ b/tests/unit/lib/utils-cn.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+import { cn } from '@/lib/utils';
+
+describe('utils: cn', () => {
+  it('handles duplicates and conditionals', () => {
+    // Non-Tailwind duplicates are kept (clsx behavior)
+    expect(cn('foo', 'foo', 'bar')).toBe('foo foo bar');
+    // Tailwind duplicates collapse
+    expect(cn('p-2', 'p-2', 'p-2')).toBe('p-2');
+    // Conditionals via object
+    expect(cn('base', { hidden: true, 'text-red-500': false })).toBe('base hidden');
+    // Arrays and falsy values are ignored
+    expect(cn(['a', null, undefined, false, 0 && 'b'], 'c')).toBe('a c');
+  });
+
+  it('applies Tailwind class merges (keeps the last in a group)', () => {
+    // Spacing
+    expect(cn('p-2', 'p-4')).toBe('p-4');
+    expect(cn('px-2', 'px-4', 'px-1')).toBe('px-1');
+    // Colors
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+    // States/variants
+    expect(cn('hover:bg-red-500', 'hover:bg-blue-500')).toBe('hover:bg-blue-500');
+    // Ring/shadow merge examples
+    expect(cn('ring-1', 'ring-2')).toBe('ring-2');
+  });
+});

--- a/tests/unit/shared/schemas/redirect-schemas.unit.test.ts
+++ b/tests/unit/shared/schemas/redirect-schemas.unit.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+
+import { redirectInputSchema, redirectOutputSchema } from '@shared/schemas/redirect';
+
+describe('Redirect Schemas', () => {
+  describe('redirectInputSchema', () => {
+    it('accepts minimal valid input (slug only) and optional fields when present', () => {
+      const ok1 = redirectInputSchema.safeParse({ slug: 'abc' });
+      expect(ok1.success).toBe(true);
+
+      const ok2 = redirectInputSchema.safeParse({
+        slug: 'my-slug',
+        ip: '127.0.0.1',
+        userAgent: 'UA',
+        referrer: 'https://example.com',
+        country: 'US',
+      });
+      expect(ok2.success).toBe(true);
+      if (ok2.success) {
+        expect(ok2.data.slug).toBe('my-slug');
+      }
+    });
+
+    it('requires non-empty slug with max length 255', () => {
+      const missing = redirectInputSchema.safeParse({});
+      expect(missing.success).toBe(false);
+      if (!missing.success) {
+        expect(missing.error.issues.some((i) => i.path.join('.') === 'slug')).toBe(true);
+      }
+
+      const empty = redirectInputSchema.safeParse({ slug: '' });
+      expect(empty.success).toBe(false);
+
+      const longSlug = 'a'.repeat(256);
+      const tooLong = redirectInputSchema.safeParse({ slug: longSlug });
+      expect(tooLong.success).toBe(false);
+    });
+
+    it('validates types of optional fields when provided', () => {
+      const bad = redirectInputSchema.safeParse({
+        slug: 'ok',
+        ip: 123,
+      } as unknown as Record<string, unknown>);
+      expect(bad.success).toBe(false);
+      if (!bad.success) {
+        // Ensure error paths include the offending key
+        expect(bad.error.issues.some((i) => i.path.join('.') === 'ip')).toBe(true);
+      }
+    });
+  });
+
+  describe('redirectOutputSchema', () => {
+    it('accepts valid output (targetUrl string or null)', () => {
+      const ok1 = redirectOutputSchema.safeParse({
+        success: true,
+        targetUrl: 'https://x',
+        slug: 's',
+      });
+      expect(ok1.success).toBe(true);
+      const ok2 = redirectOutputSchema.safeParse({ success: false, targetUrl: null, slug: 's' });
+      expect(ok2.success).toBe(true);
+    });
+
+    it('rejects invalid types for fields', () => {
+      const badSuccess = redirectOutputSchema.safeParse({
+        success: 'yes',
+        targetUrl: null,
+        slug: 's',
+      } as unknown as Record<string, unknown>);
+      expect(badSuccess.success).toBe(false);
+
+      const badTarget = redirectOutputSchema.safeParse({
+        success: true,
+        targetUrl: 123,
+        slug: 's',
+      } as unknown as Record<string, unknown>);
+      expect(badTarget.success).toBe(false);
+
+      const badSlug = redirectOutputSchema.safeParse({
+        success: true,
+        targetUrl: 'u',
+        slug: 10,
+      } as unknown as Record<string, unknown>);
+      expect(badSlug.success).toBe(false);
+    });
+  });
+});

--- a/tests/unit/shared/utils/date-utils.unit.test.ts
+++ b/tests/unit/shared/utils/date-utils.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+import { toISODate, fromNow, parseDate } from '@shared/utils/date';
+
+describe('Date Utils', () => {
+  describe('toISODate', () => {
+    it('removes milliseconds (sets them to .000Z) for Date input', () => {
+      const d = new Date('2020-01-01T12:34:56.789Z');
+      expect(toISODate(d)).toBe('2020-01-01T12:34:56.000Z');
+    });
+
+    it('removes milliseconds for string/number inputs', () => {
+      expect(toISODate('2020-01-01T12:34:56.123Z')).toBe('2020-01-01T12:34:56.000Z');
+      const ts = new Date('2020-01-01T12:34:56.987Z').getTime();
+      expect(toISODate(ts)).toBe('2020-01-01T12:34:56.000Z');
+    });
+  });
+
+  describe('fromNow', () => {
+    const now = new Date('2020-01-01T00:00:00.000Z');
+
+    it('formats past times (seconds/minutes/hours)', () => {
+      expect(fromNow(new Date(now.getTime() - 30_000), now)).toBe('30s ago');
+      expect(fromNow(new Date(now.getTime() - 120_000), now)).toBe('2m ago');
+      expect(fromNow(new Date(now.getTime() - 3 * 3_600_000), now)).toBe('3h ago');
+    });
+
+    it('formats future times (seconds/hours)', () => {
+      expect(fromNow(new Date(now.getTime() + 45_000), now)).toBe('45s from now');
+      expect(fromNow(new Date(now.getTime() + 3 * 3_600_000), now)).toBe('3h from now');
+    });
+
+    it('formats days for large differences', () => {
+      expect(fromNow(new Date(now.getTime() - 3 * 24 * 3_600_000), now)).toBe('3d ago');
+      expect(fromNow(new Date(now.getTime() + 2 * 24 * 3_600_000), now)).toBe('2d from now');
+    });
+  });
+
+  describe('parseDate', () => {
+    it('returns Date for valid inputs', () => {
+      const d1 = parseDate('2020-01-01T00:00:00Z');
+      const d2 = parseDate(new Date('2020-01-01T00:00:00Z').getTime());
+      const d3 = parseDate(new Date('2020-01-01T00:00:00Z'));
+      expect(d1).toBeInstanceOf(Date);
+      expect(d2).toBeInstanceOf(Date);
+      expect(d3).toBeInstanceOf(Date);
+      expect(d1?.toISOString()).toBe('2020-01-01T00:00:00.000Z');
+    });
+
+    it('returns null for invalid input', () => {
+      expect(parseDate('not-a-date')).toBeNull();
+      // NaN timestamp should be invalid
+      expect(parseDate(Number.NaN as unknown as number)).toBeNull();
+    });
+  });
+});

--- a/tests/unit/shared/utils/error-utils.unit.test.ts
+++ b/tests/unit/shared/utils/error-utils.unit.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import * as errorUtils from '@shared/utils/error';
+
+describe('Error Utils - withErrorReporting', () => {
+  it('invokes reporting (console.error) on thrown errors and rethrows the original error', async () => {
+    const err = new Error('boom');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      errorUtils.withErrorReporting(async () => {
+        throw err;
+      }),
+    ).rejects.toBe(err);
+
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('returns value untouched when no error and does not report', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const value = await errorUtils.withErrorReporting(async () => 42);
+    expect(value).toBe(42);
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/unit/shared/utils/random-utils.unit.test.ts
+++ b/tests/unit/shared/utils/random-utils.unit.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import {
+  randomInt,
+  randomString,
+  slugify,
+  generateSlug,
+  randomUUID,
+  generateEmail,
+} from '@shared/utils/random';
+import { withMockedRandomValues } from '@test/utils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Random Utils', () => {
+  describe('randomInt', () => {
+    it('validates inputs: finite integers and max >= min', () => {
+      expect(() => randomInt(1.5, 3)).toThrow(/integers/);
+      expect(() => randomInt(1, Number.POSITIVE_INFINITY)).toThrow(/finite/);
+      expect(() => randomInt(5, 4)).toThrow(/>=/);
+    });
+
+    it('returns values within inclusive range and can hit bounds', () => {
+      const min = 10;
+      const max = 15;
+      const range = max - min + 1; // 6
+
+      // Force modulo to 0 -> should return min
+      withMockedRandomValues([0], () => {
+        expect(randomInt(min, max)).toBe(min);
+      });
+
+      // Force modulo to range-1 -> should return max
+      withMockedRandomValues([123456 + (range - 1)], () => {
+        expect(randomInt(min, max)).toBe(max);
+      });
+
+      // Several random values map inside [min, max]
+      withMockedRandomValues([1, 2, 3, 1000, 2 ** 31], () => {
+        for (let k = 0; k < 5; k++) {
+          const n = randomInt(min, max);
+          expect(n).toBeGreaterThanOrEqual(min);
+          expect(n).toBeLessThanOrEqual(max);
+        }
+      });
+    });
+  });
+
+  describe('randomString', () => {
+    it('returns the requested length (including zero)', () => {
+      expect(randomString(0)).toBe('');
+      expect(randomString(1)).toHaveLength(1);
+      expect(randomString(12)).toHaveLength(12);
+      expect(randomString(50)).toHaveLength(50);
+    });
+
+    it('uses only lowercase base36 characters', () => {
+      const s = randomString(64);
+      expect(/^[a-z0-9]+$/.test(s)).toBe(true);
+      expect(s).toBe(s.toLowerCase());
+    });
+  });
+
+  describe('slugify', () => {
+    it('normalizes to lowercase, removes diacritics and punctuation, collapses spaces/dashes', () => {
+      expect(slugify(' Hello, World! ')).toBe('hello-world');
+      expect(slugify('Café Déjà Vu')).toBe('cafe-deja-vu');
+      expect(slugify('foo---bar   baz')).toBe('foo-bar-baz');
+      // Non-ASCII dash is removed (not treated as hyphen)
+      expect(slugify('Hello—World')).toBe('helloworld');
+    });
+  });
+
+  describe('generateSlug', () => {
+    it('returns slugified base when provided', () => {
+      expect(generateSlug({ base: ' My Title!! ' })).toBe('my-title');
+      expect(generateSlug({ base: 'Café – Déjà Vu' })).toBe('cafe-deja-vu');
+    });
+
+    it('prefixes slug when prefix is provided', () => {
+      const res = generateSlug({ base: 'Hello World', prefix: 'qr' });
+      expect(res).toBe('qr-hello-world');
+    });
+
+    it('uses random core when no base; respects randomLength and charset', () => {
+      // Mock to make the random core deterministic in length and charset
+      const randomLen = 8;
+      withMockedRandomValues([7], () => {
+        const res = generateSlug({ prefix: 'p', randomLength: randomLen });
+        const [prefix, core] = res.split('-');
+        expect(prefix).toBe('p');
+        expect(core).toHaveLength(randomLen);
+        expect(/^[a-z0-9]+$/.test(core)).toBe(true);
+      });
+    });
+  });
+
+  describe('randomUUID', () => {
+    it('uses fallback when crypto.randomUUID is unavailable and returns v4 UUID', () => {
+      const original = (globalThis.crypto as unknown as { randomUUID?: () => string }).randomUUID;
+      try {
+        (globalThis.crypto as unknown as { randomUUID?: (() => string) | undefined }).randomUUID =
+          undefined;
+        const id = randomUUID();
+        // v4 UUID pattern with correct version and variant bits
+        expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+      } finally {
+        (globalThis.crypto as unknown as { randomUUID?: (() => string) | undefined }).randomUUID =
+          original;
+      }
+    });
+
+    it('delegates to crypto.randomUUID when available', () => {
+      const spy = vi
+        .spyOn(globalThis.crypto as unknown as { randomUUID: () => string }, 'randomUUID')
+        .mockReturnValue('deadbeef-dead-4bad-8bad-deadbeefdead');
+      const id = randomUUID();
+      expect(id).toBe('deadbeef-dead-4bad-8bad-deadbeefdead');
+      spy.mockRestore();
+    });
+  });
+
+  describe('generateEmail', () => {
+    it('generates email with default domain and slugified prefix', () => {
+      const email = generateEmail({ prefix: 'My User' });
+      expect(email).toMatch(/^my-user-[a-z0-9]+@example\.test$/);
+    });
+
+    it('respects custom domain and randomLength', () => {
+      withMockedRandomValues([15], () => {
+        const email = generateEmail({ prefix: 'Q R', domain: 'test.dev', randomLength: 5 });
+        const [local, domain] = email.split('@');
+        expect(domain).toBe('test.dev');
+        const parts = local.split('-');
+        // First part(s) are slugified prefix (can contain dashes)
+        expect(parts.slice(0, parts.length - 1).join('-')).toBe('q-r');
+        const rand = parts[parts.length - 1]!;
+        expect(rand).toHaveLength(5);
+        expect(/^[a-z0-9]+$/.test(rand)).toBe(true);
+      });
+    });
+  });
+});

--- a/tests/unit/shared/utils/string-utils.unit.test.ts
+++ b/tests/unit/shared/utils/string-utils.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+
+import { capitalize, toTitleCase, normalizeWhitespace, truncate } from '@shared/utils/string';
+
+describe('String Utils', () => {
+  describe('capitalize', () => {
+    it('capitalizes the first character', () => {
+      expect(capitalize('hello')).toBe('Hello');
+      expect(capitalize('h')).toBe('H');
+      expect(capitalize('Hello')).toBe('Hello');
+    });
+
+    it('returns empty string unchanged', () => {
+      expect(capitalize('')).toBe('');
+    });
+  });
+
+  describe('toTitleCase', () => {
+    it('converts words to Title Case', () => {
+      expect(toTitleCase('hello world')).toBe('Hello World');
+      expect(toTitleCase('HELLO WORLD')).toBe('Hello World');
+    });
+
+    it('handles extra/multiple whitespace and trims ends', () => {
+      expect(toTitleCase('  hello   WORLD  ')).toBe('Hello World');
+      expect(toTitleCase('hello\tworld\nfoo')).toBe('Hello World Foo');
+      expect(toTitleCase('')).toBe('');
+    });
+  });
+
+  describe('normalizeWhitespace', () => {
+    it('trims and collapses internal whitespace to single spaces', () => {
+      expect(normalizeWhitespace('  a   b   ')).toBe('a b');
+      expect(normalizeWhitespace('a\tb\nc')).toBe('a b c');
+      expect(normalizeWhitespace('')).toBe('');
+    });
+  });
+
+  describe('truncate', () => {
+    it('returns original string when within max length', () => {
+      expect(truncate('abcdef', 6)).toBe('abcdef');
+      expect(truncate('', 10)).toBe('');
+    });
+
+    it('truncates and appends default ellipsis when needed', () => {
+      // Default ellipsis is a single-character …
+      expect(truncate('abcdef', 5)).toBe('abcd…');
+      expect(truncate('abc', 1)).toBe('…');
+    });
+
+    it('supports custom ellipsis and respects max length', () => {
+      expect(truncate('abcdef', 5, '...')).toBe('ab...');
+      // When maxLength is shorter than ellipsis length, slice ellipsis
+      expect(truncate('abcdef', 2, '...')).toBe('..');
+      expect(truncate('abcdef', 0, '...')).toBe('');
+      // Exactly equal to ellipsis length
+      expect(truncate('longstring', 3, '...')).toBe('...');
+    });
+  });
+});

--- a/tests/unit/shared/utils/trpc-ui-errors.unit.test.ts
+++ b/tests/unit/shared/utils/trpc-ui-errors.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+
+import { mapTrpcError, toUiErrorForBoundary, type UiError } from '@shared/utils/trpc-ui-errors';
+
+describe('TRPC UI Errors', () => {
+  describe('mapTrpcError', () => {
+    it('maps known top-level codes', () => {
+      expect(mapTrpcError({ code: 'UNAUTHORIZED', message: 'x' })).toMatchObject({
+        type: 'unauthorized',
+        message: 'Access denied',
+      });
+      expect(mapTrpcError({ code: 'FORBIDDEN', message: 'x' })).toMatchObject({
+        type: 'forbidden',
+        message: 'Action not allowed',
+      });
+      expect(mapTrpcError({ code: 'NOT_FOUND', message: 'x' })).toMatchObject({
+        type: 'not_found',
+        message: 'Resource not found',
+      });
+      expect(mapTrpcError({ code: 'CONFLICT', message: 'x' })).toMatchObject({
+        type: 'conflict',
+        message: 'Conflict',
+      });
+      expect(mapTrpcError({ code: 'TOO_MANY_REQUESTS', message: 'x' })).toMatchObject({
+        type: 'rate_limit',
+        message: 'Too many requests',
+      });
+      expect(mapTrpcError({ code: 'INTERNAL_SERVER_ERROR', message: 'x' })).toMatchObject({
+        type: 'internal',
+        message: 'Something went wrong',
+      });
+    });
+
+    it('maps BAD_REQUEST preferring zodError when present', () => {
+      const withZod = mapTrpcError({
+        code: 'BAD_REQUEST',
+        message: 'fallback message',
+        data: { zodError: 'Zod validation failed' },
+      });
+      expect(withZod).toMatchObject({ type: 'bad_request', message: 'Zod validation failed' });
+
+      const withMessage = mapTrpcError({ code: 'BAD_REQUEST', message: 'Bad input' });
+      expect(withMessage).toMatchObject({ type: 'bad_request', message: 'Bad input' });
+    });
+
+    it('reads code from nested data.code (tRPC client shape)', () => {
+      const ui = mapTrpcError({ message: 'x', data: { code: 'UNAUTHORIZED' } });
+      expect(ui).toMatchObject({ type: 'unauthorized' });
+    });
+
+    it('infers type from message when no code', () => {
+      expect(mapTrpcError(new Error('Access denied: token missing'))).toMatchObject({
+        type: 'unauthorized',
+      });
+      expect(mapTrpcError(new Error('User not found'))).toMatchObject({ type: 'not_found' });
+      expect(mapTrpcError(new Error('Invalid payload'))).toMatchObject({ type: 'bad_request' });
+      const unknown = mapTrpcError(new Error('Totally unexpected'));
+      expect(unknown.type).toBe('unknown');
+      expect(unknown.message).toContain('Totally unexpected');
+    });
+  });
+
+  describe('toUiErrorForBoundary', () => {
+    it('sets error name to UI_<TYPE>', () => {
+      const ui: UiError = { type: 'forbidden', message: 'Nope' };
+      const err = toUiErrorForBoundary(ui);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('UI_FORBIDDEN');
+      expect(err.message).toBe('Nope');
+    });
+  });
+});

--- a/tests/unit/shared/utils/user-utils.unit.test.ts
+++ b/tests/unit/shared/utils/user-utils.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+
+import { getInitials } from '@shared/utils/user';
+
+describe('User Utils - getInitials', () => {
+  it('returns two initials for two-word names', () => {
+    expect(getInitials('John Doe')).toBe('JD');
+    // Uses first two words only
+    expect(getInitials('Mary Ann Smith')).toBe('MA');
+  });
+
+  it('returns single initial for single-word names', () => {
+    expect(getInitials('alice')).toBe('A');
+    expect(getInitials('Bob')).toBe('B');
+  });
+
+  it('trims and handles extra whitespace', () => {
+    expect(getInitials('  bob   marley  ')).toBe('BM');
+    expect(getInitials('   single   ')).toBe('S');
+  });
+
+  it('falls back to email local-part when name is missing/empty', () => {
+    expect(getInitials(undefined, 'foo.bar@example.com')).toBe('F');
+    expect(getInitials('', 'z_user+tag@domain.test')).toBe('Z');
+    expect(getInitials('   ', 'alice@example.com')).toBe('A');
+  });
+
+  it('returns U when both name and email are missing/empty', () => {
+    expect(getInitials()).toBe('U');
+    expect(getInitials('', '')).toBe('U');
+  });
+});

--- a/tests/utils/crypto.ts
+++ b/tests/utils/crypto.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest';
+
+// Helper to mock crypto.getRandomValues deterministically
+export async function withMockedRandomValues(values: number[], fn: () => void | Promise<void>) {
+  const spy = vi.spyOn(globalThis.crypto, 'getRandomValues');
+  let i = 0;
+  function mockGRV<T extends ArrayBufferView | null>(arr: T): T {
+    if (!arr) return arr;
+    const u = arr as unknown as Uint32Array | Uint8Array;
+    if (u instanceof Uint32Array) {
+      u[0] = (values[i++] ?? 0) >>> 0;
+    } else if (u instanceof Uint8Array) {
+      const v = (values[i++] ?? 0) >>> 0;
+      for (let j = 0; j < u.length; j++) u[j] = v & 0xff;
+    }
+    return arr;
+  }
+  spy.mockImplementation(mockGRV as unknown as Crypto['getRandomValues']);
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+}

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -2,3 +2,4 @@ export * from './supabase';
 export * from './test-utils';
 export * from './ui';
 export * from './integration';
+export * from './crypto';

--- a/tests/utils/supabase.ts
+++ b/tests/utils/supabase.ts
@@ -38,6 +38,7 @@ export const createMockSupabaseClient = () =>
     })),
     auth: {
       getUser: vi.fn(),
+      getSession: vi.fn(),
       signIn: vi.fn(),
       signOut: vi.fn(),
     },
@@ -62,3 +63,29 @@ export const setupGlobalMocks = () => {
 export const cleanupGlobalMocks = () => {
   vi.clearAllMocks();
 };
+
+// Build a chained org_members query ending in maybeSingle()
+export function buildOrgMemberMaybeSingle(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        order: vi.fn(() => ({
+          limit: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data, error })),
+          })),
+        })),
+      })),
+    })),
+  } as unknown;
+}
+
+// Factory to mock server client modules at callsite
+export function serverClientMockFactory(
+  rwClient: SupabaseClient<Database>,
+  roClient?: SupabaseClient<Database>,
+) {
+  return () => ({
+    getSupabaseServerClient: async () => rwClient,
+    getSupabaseServerClientReadOnly: async () => roClient ?? rwClient,
+  });
+}

--- a/tests/utils/test-utils.ts
+++ b/tests/utils/test-utils.ts
@@ -159,3 +159,34 @@ export async function cleanupTestData() {
     console.warn('Cleanup error (ignored):', error);
   }
 }
+
+// Assert that a function/promise results in a redirect with expected URL
+export async function expectRedirect(
+  fnOrPromise: (() => unknown | Promise<unknown>) | Promise<unknown>,
+  to: string,
+) {
+  try {
+    if (typeof fnOrPromise === 'function') {
+      await fnOrPromise();
+    } else {
+      await fnOrPromise;
+    }
+    throw new Error('Expected redirect to be thrown, but none occurred');
+  } catch (e) {
+    if (e instanceof Error) {
+      const msg = e.message || '';
+      if (msg.startsWith('REDIRECT:')) {
+        if (msg !== `REDIRECT:${to}`) {
+          throw new Error(`Expected redirect to ${to} but got ${msg}`);
+        }
+        return;
+      }
+    }
+    throw e;
+  }
+}
+
+// Treat a function as a Vitest mock to access mock* helpers in tests
+export function asMock<T>(fn: T) {
+  return fn as unknown as ReturnType<typeof vi.fn>;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,34 @@ export default defineConfig({
       'tests/utils/**',
       'tests/e2e/**',
     ],
+    // Narrow coverage scope to core logic
+    coverage: {
+      all: true,
+      reporter: ['text', 'html', 'lcov'],
+      include: [
+        'src/shared/utils/**',
+        'src/shared/schemas/**',
+        'src/lib/**',
+        'src/features/auth/server.ts',
+        'src/infrastructure/trpc/routers/**',
+      ],
+      exclude: [
+        'src/i18n/**',
+        'src/shared/types/**',
+        'src/infrastructure/supabase/**',
+        'src/infrastructure/trpc/client.ts',
+        'src/infrastructure/trpc/provider.tsx',
+        'src/infrastructure/trpc/server-client.ts',
+        'src/infrastructure/trpc/server-caller.ts',
+        'src/infrastructure/trpc/utils.ts',
+      ],
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        branches: 85,
+        statements: 85,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
This PR improves test ergonomics and coverage.

Changes
- Add shared helpers:
  - Supabase org_members chain builder ()
  - Crypto randomness helper ()
  - Redirect assertion helper ()
- Refactor auth guard unit tests to use shared helpers and normalize aliases
- Add QR router integration test covering update-error branch after asset upload
- Fix typings in tests using  helper; clean lint issues

All tests pass locally (179), coverage thresholds satisfied.